### PR TITLE
Fix sphinx syntax highlighting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+   configuration: source/conf.py
+
+python:
+   install:
+   - requirements: doc-requirements.txt

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,4 @@
 sphinx==4.5.0
 nbsphinx==0.8.9
 sphinx-book-theme==0.3.3
+ipython==8.6.0


### PR DESCRIPTION
The sphinx build is full of warnings like `WARNING: Pygments lexer name 'ipython3' is not known` and syntax highlighting is not working in the built HTML.  Installing ipython is the fix, per https://nbsphinx.readthedocs.io/en/0.8.9/installation.html#Pygments-Lexer-for-Syntax-Highlighting