### PR TITLE
Fix bullet list rendering in "roll-over" notebook

### DIFF
--- a/source/pages/rollover.ipynb
+++ b/source/pages/rollover.ipynb
@@ -11,6 +11,7 @@
     "where the last few hours in the dataset are technically from the prior year.\n",
     "\n",
     "I guess the reason is due to a process roughly as follows:\n",
+    "\n",
     "- The API grabs a calendar year of data in UTC\n",
     "- The API converts to local time, thereby shifting a few January hours into the previous December\n",
     "- The API takes those few hours in the previous year and puts them at the end\n",


### PR DESCRIPTION
This is how part of the [rollover notebook](https://github.com/AssessingSolar/unofficial-psm3-userguide/blob/main/source/pages/rollover.ipynb) currently renders:

---

![image](https://user-images.githubusercontent.com/57452607/214199274-6690d39b-1dc1-4462-9431-8ba694905025.png)

---

Of course it should be like this:

---

![image](https://user-images.githubusercontent.com/57452607/214199328-7f4e062a-346b-46a3-8b36-525492bd1423.png)

So this PR adds a single empty line to make it work as intended.