### PR TITLE
Update ipython requirement

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.5.0
 nbsphinx==0.8.9
 sphinx-book-theme==0.3.3
-ipython==8.6.0
+ipython==8.10.0


### PR DESCRIPTION
Update ipython to the newest patched version (8.10), to solve known security issue. The issue was flagged by Dependabot:

![image](https://user-images.githubusercontent.com/39184289/218713531-0d11af9a-865b-434b-8381-e1498d65e8a2.png)
